### PR TITLE
댓글 쓰는 폼 엔터 잘 안 되는 문제

### DIFF
--- a/resources/views/comment/create.blade.php
+++ b/resources/views/comment/create.blade.php
@@ -37,9 +37,6 @@
             ['style', ['bold', 'italic', 'underline', 'strikethrough', 'clear']],
             ['etc', ['codeview']]
         ]
-    }).on("summernote.enter", function (we, e) {
-        $(this).summernote("pasteHTML", "<br>");
-        e.preventDefault();
     });
 })(jQuery);
 </script>


### PR DESCRIPTION
Fixes #67

원래는 줄바꿈을 br 태그로만 작동하도록 강제하고 싶었는데, summernote 기본 사양이 p 태그로 문단을 잡는 것임이 확인되어, 부득불 그냥 스타일링으로 처리하기로 결정함